### PR TITLE
fixed almost, if not all tests for task assigned

### DIFF
--- a/djangoProject1/Testing/test_configure_course.py
+++ b/djangoProject1/Testing/test_configure_course.py
@@ -5,14 +5,14 @@ from djangoProject1.models import User, Course, Section
 class TestConfigureCourseUnit(TestCase):
     def setUp(self):
         #create instructors
-        self.inst = User.objects.create(username="inst", role="Instructor", first_name="Inst", last_name="User")
-        self.ructor = User.objects.create(username="ructor", role="Instructor", first_name="Ructor", last_name="User")
+        self.inst = User.objects.create(username="inst", role="Instructor", first_name="Inst", last_name="User", skills="Good at teaching at concepts")
+        self.ructor = User.objects.create(username="ructor", role="Instructor", first_name="Ructor", last_name="User", skills="Good at teaching coding")
         self.ructor.save()
         self.inst.save()
 
         #create tas
-        self.t = User.objects.create(username="t", role="TA", first_name="T", last_name="User")
-        self.a = User.objects.create(username="a", role="TA", first_name="A", last_name="User")
+        self.t = User.objects.create(username="t", role="TA", first_name="T", last_name="User", skills="proficient in java")
+        self.a = User.objects.create(username="a", role="TA", first_name="A", last_name="User", skills="proficient in python ")
         self.t.save()
         self.a.save()
 
@@ -25,19 +25,29 @@ class TestConfigureCourseUnit(TestCase):
         self.course3.save()
 
         # Assign instructors to courses
-        self.course1.instructors.add(self.ructor)
-        self.course1.instructors.add(self.inst)
-        self.course2.instructors.add(self.ructor)
-        self.course3.instructors.add(self.inst)
+        self.course1.users.add(self.ructor)
+        self.course1.users.add(self.inst)
+        self.course2.users.add(self.ructor)
+        self.course3.users.add(self.inst)
+        # self.course1.instructors.add(self.ructor)
+        # self.course1.instructors.add(self.inst)
+        # self.course2.instructors.add(self.ructor)
+        # self.course3.instructors.add(self.inst)
 
 
         # Create labs and assign TAs
-        self.lab1 = Section.objects.create(name="Lab 1", course=self.course1, ta=self.t)
-        self.lab2 = Section.objects.create(name="Lab 2", course=self.course2, ta=self.a)
-        self.lab3 = Section.objects.create(name="Lab 3", course=self.course2, ta=self.a)
+        self.lab1 = Section.objects.create(name="Lab 1", course=self.course1, user=self.t)
+        self.lab2 = Section.objects.create(name="Lab 2", course=self.course2, user=self.a)
+        self.lab3 = Section.objects.create(name="Lab 3", course=self.course2, user=self.a)
         self.lab1.save()
         self.lab2.save()
         self.lab3.save()
+        # self.lab1 = Section.objects.create(name="Lab 1", course=self.course1, ta=self.t)
+        # self.lab2 = Section.objects.create(name="Lab 2", course=self.course2, ta=self.a)
+        # self.lab3 = Section.objects.create(name="Lab 3", course=self.course2, ta=self.a)
+        # self.lab1.save()
+        # self.lab2.save()
+        # self.lab3.save()
 
 
     def test_course_list(self):
@@ -67,30 +77,30 @@ class TestConfigureCourseUnit(TestCase):
         self.assertIn(self.a, tas)
 
     def test_inst_courses(self):
-        courses = Course.objects.filter(instructors=self.inst)
+        courses = Course.objects.filter(users=self.inst)
         self.assertEqual(courses.count(), 2)
         self.assertIn(self.course1, courses)
         self.assertIn(self.course3, courses)
 
     def test_ructor_courses(self):
-        courses = Course.objects.filter(instructors=self.ructor)
+        courses = Course.objects.filter(users=self.ructor)
         self.assertEqual(courses.count(), 2)
         self.assertIn(self.course1, courses)
         self.assertIn(self.course2, courses)
 
     def test_inst_ructor_courses(self):
-        courses = Course.objects.filter(instructors=self.inst).filter(instructors=self.ructor)
+        courses = Course.objects.filter(users=self.inst).filter(users=self.ructor)
         self.assertEqual(courses.count(), 1)
         self.assertIn(self.course1, courses)
-        self.assertEqual(self.course1.instructors.count(), 2)
+        self.assertEqual(self.course1.users.count(), 2)
 
     def test_t_labs(self):
-        labs = Section.objects.filter(ta=self.t)
+        labs = Section.objects.filter(user=self.t)
         self.assertEqual(labs.count(), 1)
         self.assertIn(self.lab1, labs)
 
     def test_a_labs(self):
-        labs = Section.objects.filter(ta=self.a)
+        labs = Section.objects.filter(user=self.a)
         self.assertEqual(labs.count(), 2)
         self.assertIn(self.lab2, labs)
         self.assertIn(self.lab3, labs)

--- a/djangoProject1/Testing/test_configure_user.py
+++ b/djangoProject1/Testing/test_configure_user.py
@@ -5,11 +5,11 @@ class TestConfigureUserUnit(TestCase):
     def setUp(self):
         #create some users
         self.admin = User.objects.create(first_name='Ad', last_name='Min', username='admin',
-                                         email='admin@uwm.edu', phone_number="1234567890", role='Admin')
+                                         email='admin@uwm.edu', phone_number="1234567890", role='Admin', skills='Admin skills')
         self.instructor = User.objects.create(first_name='Inst', last_name='Ructor', username='instructor',
-                                         email='instructor@uwm.edu', phone_number="0123456789", role='Instructor')
+                                         email='instructor@uwm.edu', phone_number="0123456789", role='Instructor',skills='Good at teaching')
         self.ta = User.objects.create(first_name='T', last_name='A', username='ta',
-                                         email='ta@uwm.edu', phone_number="9876543210", role='TA')
+                                         email='ta@uwm.edu', phone_number="9876543210", role='TA', skills='Proficient in java')
         self.admin.save()
         self.instructor.save()
         self.ta.save()
@@ -17,9 +17,9 @@ class TestConfigureUserUnit(TestCase):
         #create some courses/labs
         self.course = Course.objects.create(name="Course 1")
         self.course.save()
-        self.course.instructors.add(self.instructor)
+        self.course.users.add(self.instructor)
 
-        self.lab = Section.objects.create(name="Lab 1", course=self.course, ta=self.ta)
+        self.lab = Section.objects.create(name="Lab 1", course=self.course, user=self.ta)
         self.lab.save()
 
     def test_user_list(self):
@@ -62,8 +62,8 @@ class TestConfigureUserUnit(TestCase):
         self.assertEqual(self.admin.phone_number, '1234567890')
 
     def test_admin_courses(self):
-        courses = Course.objects.filter(instructors=self.admin)
-        labs = Section.objects.filter(ta=self.admin)
+        courses = Course.objects.filter(users=self.admin)
+        labs = Section.objects.filter(user=self.admin)
         self.assertEqual(courses.count(), 0)
         self.assertEqual(labs.count(), 0)
 
@@ -75,8 +75,8 @@ class TestConfigureUserUnit(TestCase):
         self.assertEqual(self.instructor.phone_number, '0123456789')
 
     def test_instructor_courses(self):
-        courses = Course.objects.filter(instructors=self.instructor)
-        labs = Section.objects.filter(ta=self.instructor)
+        courses = Course.objects.filter(users=self.instructor)
+        labs = Section.objects.filter(user=self.instructor)
         self.assertEqual(courses.count(), 1)
         self.assertEqual(labs.count(), 0)
         self.assertIn(self.course, courses)
@@ -89,8 +89,8 @@ class TestConfigureUserUnit(TestCase):
         self.assertEqual(self.ta.phone_number, '9876543210')
 
     def test_ta_courses(self):
-        courses = Course.objects.filter(instructors=self.ta)
-        labs = Section.objects.filter(ta=self.ta)
+        courses = Course.objects.filter(users=self.ta)
+        labs = Section.objects.filter(user=self.ta)
         self.assertEqual(courses.count(), 0)
         self.assertEqual(labs.count(), 1)
         self.assertIn(self.lab, labs)

--- a/djangoProject1/Testing/test_create_course.py
+++ b/djangoProject1/Testing/test_create_course.py
@@ -13,7 +13,7 @@ class CreateCourseUnitTest(TestCase):
     def test_create_course(self):
         course = CreateCourse.create_course("name", self.user)
         self.assertEqual(course.name,"name")
-        self.assertEqual(course.instructors.first(), self.user)
+        self.assertEqual(course.users.first(), self.user)
 
     #if anything is wrong then we want to set course to none and don't save it to the database
     def test_no_name(self):
@@ -40,7 +40,7 @@ class CreateCourseUnitTest(TestCase):
     def test_course_already_exists(self):
         course = CreateCourse.create_course("name", self.user)
         self.assertEqual(course.name, "name")
-        self.assertEqual(course.instructors.first(), self.user)
+        self.assertEqual(course.users.first(), self.user)
 
         course2 = CreateCourse.create_course("name", self.user)
         self.assertEqual(course2, None)


### PR DESCRIPTION
What I worked on:
- worked on the test_configure_course suite
     - Passing all tests except test_a_labs and test_t_labs, both having problems with count() being either 1 or 2, when it was 0
- worked on the test_configure_user suite
     - Passing all tests except test_ta_course, where it epects the count to be 1 but it is 0.
- worked on the test_create_course test suite
     - Passing all tests except 2, but I believe those have to do with line 86 in Administrator.py where it references 
     -  course.instructors.add(instructor) I believe it should be course.users.add(instructor), will make change soon, but I am doing 
         an initial pull before making any changes to Administrator.py(peer review/double check into problem will be appreciated)